### PR TITLE
Add `embed` Query Param

### DIFF
--- a/src/partials/footer.hbs
+++ b/src/partials/footer.hbs
@@ -1,3 +1,13 @@
+<!-- Check if embedded view -->
+<script>
+  (function() {
+    const search = window.location.search;
+    if (search.indexOf('embed=1') !== -1 || search.indexOf('embed=true') !== -1) {
+      document.body.className += ' is-embedded';
+    }
+  })();
+</script>
+
 <!-- Footer -->
 <footer class="footer" role="content" aria-label="footer">
 

--- a/src/styles/templates/page.scss
+++ b/src/styles/templates/page.scss
@@ -67,3 +67,15 @@
   max-width: 250px;
   height: auto;
 }
+
+
+// Hide some stuff in embed mode
+body.is-embedded {
+  .header {
+    display: none;
+  }
+
+  .footer {
+    display: none;
+  }
+}


### PR DESCRIPTION
Adds the ability to add the query param `?embed=true` to make remove the header and footer on the page. At some point I want the help page to be built into MEW via an iframe, and this will make it look less janky.

Not sure how checking in the dist folder goes with this, so I only changed `src/*` files. Might require a rebuild.

<img width="1363" alt="screen shot 2018-01-24 at 3 48 08 pm" src="https://user-images.githubusercontent.com/649992/35356324-0f15a4e2-011e-11e8-93b9-515bf7c9457b.png">
